### PR TITLE
Addition of Moment Timezone to Global Modules and Character Encoding Support for FileEngine

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "helmet": "^4.6.0",
     "lodash": "^4.17.21",
     "moment": "^2.29.1",
+    "moment-timezone": "^0.5.34",
     "object-collection": "^3.0.1",
     "path-to-regexp": "^6.2.0",
     "pluralize": "^8.0.0",

--- a/src/FileEngine.ts
+++ b/src/FileEngine.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import PATH from "path";
 import {getInstance} from "../index";
 import fse from "fs-extra";
+import {encodingType} from "../types";
 
 const $ = getInstance()
 
@@ -75,7 +76,7 @@ $.file = {
      * @param $path
      * @param $options
      */
-    get($path: string, $options?: { encoding?: null, flag?: string } | null): string | Buffer | false {
+    get($path: string, $options?: { encoding?: encodingType, flag?: string } | null): string | Buffer | false {
         const fileExists = $.file.exists($path);
 
         if (!fileExists) {
@@ -89,7 +90,7 @@ $.file = {
      * @param $path
      * @param $options
      */
-    read($path: string, $options?: { encoding?: null, flag?: string }): string | Buffer | false {
+    read($path: string, $options?: { encoding?: encodingType, flag?: string }): string | Buffer | false {
         return $.file.get($path, $options);
     },
 
@@ -99,7 +100,7 @@ $.file = {
      * @param $options
      */
     readDirectory($path: string, $options?: {
-        encoding?: null,
+        encoding?: encodingType,
         writeFileTypes?: string,
     }): string[] | Buffer[] | false {
         return this.getDirectory($path, $options);
@@ -111,7 +112,7 @@ $.file = {
      * @param $options
      */
     getDirectory($path: string, $options?: {
-        encoding?: null,
+        encoding?: encodingType,
         writeFileTypes?: string,
     }): string[] | Buffer[] | false {
         const fileExists = $.file.exists($path);
@@ -285,7 +286,7 @@ $.file = {
      * @param $isFile
      */
     makeDirIfNotExist($path: string, $isFile = false) {
-        if ($isFile === true) {
+        if ($isFile) {
             $path = PATH.dirname($path);
         }
 

--- a/src/Functions/modules.fn.ts
+++ b/src/Functions/modules.fn.ts
@@ -1,6 +1,7 @@
 import BuildUrl = require("build-url");
 import lodash, {LoDashStatic} from "lodash";
 import moment from "moment";
+import momentT from "moment-timezone";
 
 const modules = {
     /**
@@ -16,6 +17,10 @@ const modules = {
 
     moment(): typeof moment {
         return moment;
+    },
+
+    momentT(): typeof momentT {
+        return momentT
     }
 };
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -84,6 +84,11 @@ declare namespace Xpresser {
 
     export type TodoFunction = (next: () => void, $: DollarSign) => any;
 
+    /**
+     * supported character encoding
+     */
+    export type encodingType = 'ascii' | 'utf8' | 'utf-8' | 'utf16le' | 'ucs2' | 'ucs-2' | 'base64' | 'base64url' | 'latin1' | 'binary' | 'hex';
+
     export interface DollarSign {
         config: ObjectCollection;
         options: Options;
@@ -193,14 +198,14 @@ declare namespace Xpresser {
              * @param $path
              * @param $options
              */
-            get($path: string, $options?: { encoding?: null, flag?: string }): string | Buffer | false;
+            get($path: string, $options?: { encoding?: encodingType, flag?: string }): string | Buffer | false;
 
             /**
              * Get/Read File
              * @param $path
              * @param $options
              */
-            read($path: string, $options?: { encoding?: null, flag?: string }): string | Buffer | false;
+            read($path: string, $options?: { encoding?: encodingType, flag?: string }): string | Buffer | false;
 
             /**
              * Get Directory
@@ -208,7 +213,7 @@ declare namespace Xpresser {
              * @param $options
              */
             getDirectory($path: string, $options?: {
-                encoding?: null,
+                encoding?: encodingType,
                 writeFileTypes?: string,
             }): string[] | Buffer[] | false;
 
@@ -218,7 +223,7 @@ declare namespace Xpresser {
              * @param $options
              */
             readDirectory($path: string, $options?: {
-                encoding?: null,
+                encoding?: encodingType,
                 writeFileTypes?: string,
             }): string[] | Buffer[] | false;
 


### PR DESCRIPTION
I added `moment-timezone` module to the globally available module, it's quite a useful package that works perfectly along side `moment`.

Furthermore, I noticed the file encoding property only allowed for `null` and `undefined` values only, I then added the alias to support the required character encoding when using the `fs` module.

```typescript
const fetchFile = $.file.fs().existsSync(__PATH__, {
     encoding: "utf8" // This is now valid
});
```